### PR TITLE
Experiment: side-by-side with grid and resize handle

### DIFF
--- a/packages/cells/src/resizeHandle.ts
+++ b/packages/cells/src/resizeHandle.ts
@@ -1,0 +1,69 @@
+import { Widget } from '@lumino/widgets';
+import { Message } from '@lumino/messaging';
+
+const RESIZE_HANDLE_CLASS = 'jp-CellResizeHandle';
+
+const CELL_RESIZED_CLASS = 'jp-mod-resizedCell';
+
+export class ResizeHandle extends Widget {
+  private _isActive: boolean = false;
+  private _isDragging: boolean = false;
+
+  constructor(protected targetNode: HTMLElement) {
+    super();
+    this.addClass(RESIZE_HANDLE_CLASS);
+  }
+
+  protected onAfterAttach(msg: Message) {
+    super.onAfterAttach(msg);
+    this.node.addEventListener('dblclick', this);
+    this.node.addEventListener('mousedown', this);
+  }
+
+  protected onAfterDetach(msg: Message) {
+    super.onAfterAttach(msg);
+    this.node.removeEventListener('dblclick', this);
+    this.node.removeEventListener('mousedown', this);
+  }
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+      case 'dblclick':
+        this.targetNode.classList.remove(CELL_RESIZED_CLASS);
+        this.targetNode.style.gridTemplateColumns = '';
+        this._isActive = false;
+        break;
+      case 'mousedown':
+        this._isDragging = true;
+        if (!this._isActive) {
+          this.targetNode.classList.add(CELL_RESIZED_CLASS);
+          this._isActive = true;
+        }
+        window.addEventListener('mousemove', this);
+        window.addEventListener('mouseup', this);
+        break;
+      case 'mousemove':
+        if (!this._isActive || !this._isDragging) {
+          return;
+        }
+        this.targetNode.style.gridTemplateColumns =
+          (event as MouseEvent).clientX -
+          this.targetNode.getBoundingClientRect().x +
+          'px 1fr';
+        break;
+      case 'mouseup':
+        this._isDragging = false;
+        window.removeEventListener('mousemove', this);
+        window.removeEventListener('mouseup', this);
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/packages/cells/src/resizeHandle.ts
+++ b/packages/cells/src/resizeHandle.ts
@@ -5,9 +5,13 @@ const RESIZE_HANDLE_CLASS = 'jp-CellResizeHandle';
 
 const CELL_RESIZED_CLASS = 'jp-mod-resizedCell';
 
+/**
+ * A handle that allows to change input/output proportions in side-by-side mode.
+ */
 export class ResizeHandle extends Widget {
   private _isActive: boolean = false;
   private _isDragging: boolean = false;
+  private _mouseOffset: number;
 
   constructor(protected targetNode: HTMLElement) {
     super();
@@ -40,6 +44,8 @@ export class ResizeHandle extends Widget {
         this._isActive = false;
         break;
       case 'mousedown':
+        this._mouseOffset =
+          (event as MouseEvent).clientX - this.node.getBoundingClientRect().x;
         this._isDragging = true;
         if (!this._isActive) {
           this.targetNode.classList.add(CELL_RESIZED_CLASS);
@@ -54,8 +60,9 @@ export class ResizeHandle extends Widget {
         }
         this.targetNode.style.gridTemplateColumns =
           (event as MouseEvent).clientX -
-          this.targetNode.getBoundingClientRect().x +
-          'px 1fr';
+          this.targetNode.getBoundingClientRect().x -
+          this._mouseOffset +
+          'px min-content 1fr';
         break;
       case 'mouseup':
         this._isDragging = false;

--- a/packages/cells/src/resizeHandle.ts
+++ b/packages/cells/src/resizeHandle.ts
@@ -12,6 +12,7 @@ export class ResizeHandle extends Widget {
   private _isActive: boolean = false;
   private _isDragging: boolean = false;
   private _mouseOffset: number;
+  private _protectedWidth = 10;
 
   constructor(protected targetNode: HTMLElement) {
     super();
@@ -54,16 +55,20 @@ export class ResizeHandle extends Widget {
         window.addEventListener('mousemove', this);
         window.addEventListener('mouseup', this);
         break;
-      case 'mousemove':
+      case 'mousemove': {
         if (!this._isActive || !this._isDragging) {
           return;
         }
+        const targetRect = this.targetNode.getBoundingClientRect();
+        const inputWidth =
+          (event as MouseEvent).clientX - targetRect.x - this._mouseOffset;
         this.targetNode.style.gridTemplateColumns =
-          (event as MouseEvent).clientX -
-          this.targetNode.getBoundingClientRect().x -
-          this._mouseOffset +
-          'px min-content 1fr';
+          Math.min(
+            Math.max(inputWidth, this._protectedWidth),
+            targetRect.width - this._protectedWidth
+          ) + 'px min-content 1fr';
         break;
+      }
       case 'mouseup':
         this._isDragging = false;
         window.removeEventListener('mousemove', this);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -220,7 +220,6 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     input.addClass(CELL_INPUT_AREA_CLASS);
     inputWrapper.addWidget(inputCollapser);
     inputWrapper.addWidget(input);
-    inputWrapper.addWidget(new ResizeHandle(this.node));
     (this.layout as PanelLayout).addWidget(inputWrapper);
 
     this._inputPlaceholder = new InputPlaceholder(() => {
@@ -748,7 +747,8 @@ export class CodeCell extends Cell<ICodeCellModel> {
       output.outputLengthChanged.connect(this._outputLengthHandler, this);
       outputWrapper.addWidget(outputCollapser);
       outputWrapper.addWidget(output);
-      (this.layout as PanelLayout).insertWidget(2, outputWrapper);
+      (this.layout as PanelLayout).insertWidget(2, new ResizeHandle(this.node));
+      (this.layout as PanelLayout).insertWidget(3, outputWrapper);
 
       if (model.isDirty) {
         this.addClass(DIRTY_CLASS);

--- a/packages/cells/src/widget.ts
+++ b/packages/cells/src/widget.ts
@@ -73,6 +73,9 @@ import {
 } from './model';
 
 import { InputPlaceholder, OutputPlaceholder } from './placeholder';
+
+import { ResizeHandle } from './resizeHandle';
+
 import { Signal } from '@lumino/signaling';
 import { addIcon } from '@jupyterlab/ui-components';
 
@@ -217,6 +220,7 @@ export class Cell<T extends ICellModel = ICellModel> extends Widget {
     input.addClass(CELL_INPUT_AREA_CLASS);
     inputWrapper.addWidget(inputCollapser);
     inputWrapper.addWidget(input);
+    inputWrapper.addWidget(new ResizeHandle(this.node));
     (this.layout as PanelLayout).addWidget(inputWrapper);
 
     this._inputPlaceholder = new InputPlaceholder(() => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -2174,7 +2174,7 @@ function addCommands(
         .then(result => {
           if (result.value) {
             document.documentElement.style.setProperty(
-              '--jp-side-by-side-input-size',
+              '--jp-side-by-side-output-size',
               `${result.value}fr`
             );
           }

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   Dialog,
   ICommandPalette,
+  InputDialog,
   ISessionContextDialogs,
   MainAreaWidget,
   sessionContextDialogs,
@@ -241,6 +242,8 @@ namespace CommandIDs {
   export const renderSideBySide = 'notebook:render-side-by-side';
 
   export const renderNotSideBySide = 'notebook:render-not-side-by-side';
+
+  export const setSideBySideRatio = 'notebook:set-side-by-side-ratio';
 
   export const enableOutputScrolling = 'notebook:enable-output-scrolling';
 
@@ -2161,6 +2164,24 @@ function addCommands(
     },
     isEnabled
   });
+  commands.addCommand(CommandIDs.setSideBySideRatio, {
+    label: trans.__('Set side-by-side ratio'),
+    execute: args => {
+      InputDialog.getNumber({
+        title: trans.__('Width of the output in side-by-side mode'),
+        value: 1
+      })
+        .then(result => {
+          if (result.value) {
+            document.documentElement.style.setProperty(
+              '--jp-side-by-side-input-size',
+              `${result.value}fr`
+            );
+          }
+        })
+        .catch(console.error);
+    }
+  });
   commands.addCommand(CommandIDs.showAllOutputs, {
     label: trans.__('Expand All Outputs'),
     execute: args => {
@@ -2337,6 +2358,7 @@ function populatePalette(
     CommandIDs.hideAllOutputs,
     CommandIDs.showAllOutputs,
     CommandIDs.renderSideBySide,
+    CommandIDs.setSideBySideRatio,
     CommandIDs.enableOutputScrolling,
     CommandIDs.disableOutputScrolling
   ].forEach(command => {

--- a/packages/notebook-extension/src/index.ts
+++ b/packages/notebook-extension/src/index.ts
@@ -7,7 +7,6 @@
 
 import {
   ILayoutRestorer,
-  JupyterLab,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -2147,10 +2146,7 @@ function addCommands(
     execute: args => {
       const current = getCurrent(tracker, shell, args);
       if (current) {
-        if (!(app instanceof JupyterLab)) {
-          return NotebookActions.renderSideBySide(current);
-        }
-        return NotebookActions.renderSideBySide(current, app);
+        return NotebookActions.renderSideBySide(current.content);
       }
     },
     isEnabled
@@ -2160,7 +2156,7 @@ function addCommands(
     execute: args => {
       const current = getCurrent(tracker, shell, args);
       if (current) {
-        return NotebookActions.renderNotSideBySide();
+        return NotebookActions.renderNotSideBySide(current.content);
       }
     },
     isEnabled

--- a/packages/notebook/src/actions.tsx
+++ b/packages/notebook/src/actions.tsx
@@ -17,7 +17,6 @@ import {
   isRawCellModel,
   MarkdownCell
 } from '@jupyterlab/cells';
-import { JupyterLab } from '@jupyterlab/application';
 import * as nbformat from '@jupyterlab/nbformat';
 import { KernelMessage } from '@jupyterlab/services';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
@@ -27,13 +26,14 @@ import { ElementExt } from '@lumino/domutils';
 import { ISignal, Signal } from '@lumino/signaling';
 import * as React from 'react';
 import { INotebookModel } from './model';
-import { NotebookPanel } from './panel';
 import { Notebook } from './widget';
 
 /**
  * The mimetype used for Jupyter cell data.
  */
 const JUPYTER_CELL_MIME = 'application/vnd.jupyter.cells';
+
+const SIDE_BY_SIDE_CLASS = 'jp-mod-sideBySide';
 
 export class KernelError extends Error {
   /**
@@ -1319,76 +1319,19 @@ export namespace NotebookActions {
   /**
    * Render side-by-side.
    *
-   * @param panel - The current notebook panel.
+   * @param notebook - The target notebook widget.
    */
-  export function renderSideBySide(
-    panel: NotebookPanel,
-    app?: JupyterLab
-  ): void {
-    Private.sideBySide = true;
-    const applySideBySide = () => {
-      if (!Private.sideBySide) {
-        return;
-      }
-
-      const halfWidth = panel.node.clientWidth / 2;
-      const nodes = document.getElementsByClassName('jp-CodeCell');
-      for (let i = 0; i < nodes.length; i++) {
-        const ele = nodes.item(i) as HTMLElement;
-        ele.style.display = 'flex';
-        ele.style.alignItems = 'flex-start';
-        ele.style.flexWrap = 'wrap';
-        ele.style.direction = 'row';
-      }
-      const inputarea = document.getElementsByClassName('jp-InputArea-editor');
-      for (let j = 0; j < inputarea.length; j++) {
-        const area = inputarea.item(j) as HTMLElement;
-        area.style.minWidth = `calc(${halfWidth}px - 30px)`;
-        area.style.maxWidth = `calc(${halfWidth}px - 30px)`;
-      }
-      const outputarea = document.getElementsByClassName('jp-OutputArea');
-      for (let k = 0; k < outputarea.length; k++) {
-        (outputarea.item(
-          k
-        ) as HTMLElement).style.maxWidth = `calc(${halfWidth}px - 50px)`;
-      }
-    };
-    applySideBySide();
-
-    panel.content.activeCellChanged.connect(() => {
-      applySideBySide();
-    });
-    if (app) {
-      app.shell.layoutModified.connect(() => {
-        applySideBySide();
-      });
-    }
+  export function renderSideBySide(notebook: Notebook): void {
+    notebook.node.classList.add(SIDE_BY_SIDE_CLASS);
   }
 
   /**
    * Render not side-by-side.
    *
+   * @param notebook - The target notebook widget.
    */
-  export function renderNotSideBySide(): void {
-    Private.sideBySide = false;
-    const removeSideBySide = () => {
-      const nodes = document.getElementsByClassName('jp-CodeCell');
-      for (let i = 0; i < nodes.length; i++) {
-        const ele = nodes.item(i) as HTMLElement;
-        ele.style.display = 'initial';
-      }
-      const inputarea = document.getElementsByClassName('jp-InputArea-editor');
-      for (let j = 0; j < inputarea.length; j++) {
-        const area = inputarea.item(j) as HTMLElement;
-        area.style.minWidth = 'initial';
-        area.style.maxWidth = 'initial';
-      }
-      const outputarea = document.getElementsByClassName('jp-OutputArea');
-      for (let k = 0; k < outputarea.length; k++) {
-        (outputarea.item(k) as HTMLElement).style.maxWidth = 'initial';
-      }
-    };
-    removeSideBySide();
+  export function renderNotSideBySide(notebook: Notebook): void {
+    notebook.node.classList.remove(SIDE_BY_SIDE_CLASS);
   }
 
   /**
@@ -2330,6 +2273,4 @@ namespace Private {
     }
     cell.value.text = newHeader + source;
   }
-
-  export var sideBySide = false;
 }

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -297,11 +297,18 @@
 /*-----------------------------------------------------------------------------
 | Side-by-side Mode (.jp-mod-sideBySide)
 |----------------------------------------------------------------------------*/
+:root {
+  --jp-side-by-side-input-size: 1fr;
+}
+
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
   display: grid;
   column-gap: var(--jp-cell-padding);
   /* in side-by-side mode there are three rows: header, cell (input and output), footer */
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(
+      0,
+      var(--jp-side-by-side-input-size)
+    );
   /* in side-by-side mode there are two columns: input and output; header and footer span both of the columns */
   grid-template-rows: auto minmax(0, 1fr) auto;
   grid-template-areas:

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -298,7 +298,7 @@
 | Side-by-side Mode (.jp-mod-sideBySide)
 |----------------------------------------------------------------------------*/
 :root {
-  --jp-side-by-side-input-size: 1fr;
+  --jp-side-by-side-output-size: 1fr;
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
@@ -307,7 +307,7 @@
   /* in side-by-side mode there are three rows: header, cell (input and output), footer */
   grid-template-columns: minmax(0, 1fr) minmax(
       0,
-      var(--jp-side-by-side-input-size)
+      var(--jp-side-by-side-output-size)
     );
   /* in side-by-side mode there are two columns: input and output; header and footer span both of the columns */
   grid-template-rows: auto minmax(0, 1fr) auto;

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -295,6 +295,58 @@
 }
 
 /*-----------------------------------------------------------------------------
+| Side-by-side Mode (.jp-mod-sideBySide)
+|----------------------------------------------------------------------------*/
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
+  display: grid;
+  column-gap: var(--jp-cell-padding);
+  /* in side-by-side mode there are three rows: header, cell (input and output), footer */
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  /* in side-by-side mode there are two columns: input and output; header and footer span both of the columns */
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    'header header'
+    'input output'
+    'footer footer';
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellHeader {
+  grid-area: header;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-Cell-inputWrapper {
+  grid-area: input;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-Cell-outputWrapper {
+  grid-area: output;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellFooter {
+  grid-area: footer;
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellResizeHandle {
+  display: block;
+  flex: 0 0 5px;
+  margin-left: 5px;
+  width: 5px;
+  height: 100%;
+  background: var(--jp-border-color2);
+  cursor: ew-resize;
+}
+
+.jp-mod-sideBySide.jp-Notebook
+  .jp-CodeCell.jp-mod-resizedCell
+  .jp-CellResizeHandle {
+  background: var(--jp-border-color0);
+}
+
+.jp-CellResizeHandle {
+  display: none;
+}
+
+/*-----------------------------------------------------------------------------
 | Placeholder
 |----------------------------------------------------------------------------*/
 

--- a/packages/notebook/style/base.css
+++ b/packages/notebook/style/base.css
@@ -303,18 +303,15 @@
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell {
   display: grid;
-  column-gap: var(--jp-cell-padding);
-  /* in side-by-side mode there are three rows: header, cell (input and output), footer */
-  grid-template-columns: minmax(0, 1fr) minmax(
+  grid-template-columns: minmax(0, 1fr) min-content minmax(
       0,
       var(--jp-side-by-side-output-size)
     );
-  /* in side-by-side mode there are two columns: input and output; header and footer span both of the columns */
   grid-template-rows: auto minmax(0, 1fr) auto;
   grid-template-areas:
-    'header header'
-    'input output'
-    'footer footer';
+    'header header header'
+    'input handle output'
+    'footer footer footer';
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellHeader {
@@ -326,6 +323,8 @@
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-Cell-outputWrapper {
+  /* overwrite the default margin (no vertical separation needed in side by side move */
+  margin-top: 0;
   grid-area: output;
 }
 
@@ -334,18 +333,25 @@
 }
 
 .jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellResizeHandle {
+  grid-area: handle;
+  user-select: none;
   display: block;
-  flex: 0 0 5px;
-  margin-left: 5px;
-  width: 5px;
   height: 100%;
-  background: var(--jp-border-color2);
   cursor: ew-resize;
+  padding: 0 var(--jp-cell-padding);
+}
+
+.jp-mod-sideBySide.jp-Notebook .jp-CodeCell .jp-CellResizeHandle::after {
+  content: '';
+  display: block;
+  background: var(--jp-border-color2);
+  height: 100%;
+  width: 5px;
 }
 
 .jp-mod-sideBySide.jp-Notebook
   .jp-CodeCell.jp-mod-resizedCell
-  .jp-CellResizeHandle {
+  .jp-CellResizeHandle::after {
   background: var(--jp-border-color0);
 }
 


### PR DESCRIPTION
This is an experiment demonstrating feasibility of using CSS grid for side-by-side rendering. No action required here, I will post the same on the main PR in the JupyterLab repo.

![side-by-side-demo](https://user-images.githubusercontent.com/5832902/126575233-d04f3ffb-fb46-4683-b52e-a27c72b0459d.gif)